### PR TITLE
Prevent data loss on site reload

### DIFF
--- a/js/openGL.js
+++ b/js/openGL.js
@@ -174,6 +174,10 @@ function newShader(vs, shaderCode)
             console.log(res.mInfo); 
                 return res.mInfo;
         }
+
+        if (typeof(Storage) !== "undefined"){
+            localStorage.lastValidCode= shaderCode;
+        }
     
 
 	if (mProgram !== null)

--- a/js/pageGlobals.js
+++ b/js/pageGlobals.js
@@ -950,7 +950,11 @@ $( document ).ready(function()
                             mCompileTimer = setTimeout(setShaderFromEditor, 200);
     });
     editor.$blockScrolling = Infinity;
-    editor.setValue("void main () {\n\tgl_FragColor = vec4(black, 1.0);\n}", -1);
+    if (typeof(Storage) !== "undefined" && typeof(localStorage.lastValidCode) !== "undefined"){
+        editor.setValue(localStorage.lastValidCode,-1);
+    }else{
+        editor.setValue("void main () {\n\tgl_FragColor = vec4(black, 1.0);\n}", -1);
+    }
    
     // mCodeMirror.on("drop", function( mCodeMirror, event )
     //             {


### PR DESCRIPTION
I lost all my code due to my browsers `backspace` behaviour (history back) **twice today**.

Thus i implemented a persistend storage of the code on each successful compilation if `localStorage` is availiable.
On site loading, the editor tries to load that code, or else sets the default value.

Hope you accept my PR, to prevent such events for other users in the future.
