### PR TITLE
Update instructions for serving w/ Python + HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ In addition to the standard OpenGL Fragment Shader language, the following are a
 - keyboard data in row 0 of texture - not recently tested
 - open file is not totally safe; it's only checking for filename extension ".frag"
 - images save as .png
-- The_Force/shaderExperiments contains several examples to get you started
-- The_Force/help contains helpful documents
+- [The_Force/shaderExperiments](./help) contains several examples to get you started
+- [The_Force/help](./help) contains helpful documents, including **instructions to run local/offline (it's easy!)**
 
 ## To Do 
 
@@ -35,17 +35,10 @@ In addition to the standard OpenGL Fragment Shader language, the following are a
 
 ## Sources
 
-https://github.com/ajaxorg/ace
-
-http://darsa.in/fpsmeter/ also https://github.com/darsain/fpsmeter
-
-http://jquery.com
-
-http://www.flaticon.com
-
-https://github.com/eligrey/FileSaver.js
-
-https://github.com/eligrey/canvas-toBlob.js
-
-https://github.com/marmorkuchen-net/osc-js
-
+* https://github.com/ajaxorg/ace
+* http://darsa.in/fpsmeter/ also https://github.com/darsain/fpsmeter
+* http://jquery.com
+* http://www.flaticon.com
+* https://github.com/eligrey/FileSaver.js
+* https://github.com/eligrey/canvas-toBlob.js
+* https://github.com/marmorkuchen-net/osc-js

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ In addition to the standard OpenGL Fragment Shader language, the following are a
 - [The_Force/shaderExperiments](./help) contains several examples to get you started
 - [The_Force/help](./help) contains helpful documents, including **instructions to run local/offline (it's easy!)**
 - line in and microphone only work in Google Chrome, and requires HTTPS
+- <kbd>ctrl</kbd>+<kbd>shift</kbd> will toggle text visibility
 - backbuffer is a copy of the previous frame's frontbuffer
 - ctl key to hide/show overlay interface
 - 512 fft in row 0; waveform in row 1

--- a/README.md
+++ b/README.md
@@ -10,15 +10,16 @@ In addition to the standard OpenGL Fragment Shader language, the following are a
 
 ### Additionally helpful to know
 
-- backbuffer is a copy of the previous frame's frontbuffer
-- line in and microphone only work in Google Chrome
-- ctl key to hide/show overlay interface
-- 512 fft in row 0; waveform in row 1
-- keyboard data in row 0 of texture - not recently tested
-- open file is not totally safe; it's only checking for filename extension ".frag"
-- images save as .png
 - [The_Force/shaderExperiments](./help) contains several examples to get you started
 - [The_Force/help](./help) contains helpful documents, including **instructions to run local/offline (it's easy!)**
+- line in and microphone only work in Google Chrome, and requires HTTPS
+- backbuffer is a copy of the previous frame's frontbuffer
+- ctl key to hide/show overlay interface
+- 512 fft in row 0; waveform in row 1
+- keyboard data in row 0 of texture (`channel0`) - not recently tested
+- open file is not totally safe; it's only checking for filename extension ".frag"
+- images save as .png
+
 
 ## To Do 
 

--- a/help/osx-apache-config.md
+++ b/help/osx-apache-config.md
@@ -1,3 +1,16 @@
+### Python
+
+Simple, but assumes you've got Python (anyway you should if you are on OS X; if in doubt, just run `python --version`).
+
+You can do this instantly, but you won't be able to use the microphone input (requires HTTPS)
+
+```bash
+cd /path/to/the_force
+python -m SimpleHTTPServer 80    # or whatever other port you want.
+```
+
+**To use HTTPS with `SimpleHTTPServer` is actually pretty simple!** Just follow [these instructions](https://gist.github.com/dergachev/7028596). Then when you access the URL just don't forget the `https` in the URL. You'll have to "accept" the invalid HTTPS certificate, but that's fine, it's just little old you.
+
 ### Apache
 
 ##### this guide assumes you've not made a bunch of changes to the default apache2 config
@@ -37,11 +50,3 @@
 - navigate to http://localhost/the_force
     you should see The_Force IDE!
 
-### Python
-
-Simpler but may have some limitations. For example you must use HTTPS to use microphone input, and this way won't allow HTTPS right out of box.
-
-```bash
-cd /path/to/the_force
-python -m SimpleHTTPServer 80    # or whatever other port you want.
-```


### PR DESCRIPTION
Thanks to the helpful tip in #10.

I changed the order too. I think people will pick the server they want to use. Luckily both come on OS X so it seems fine to weigh them the same. The diff. is that Python can be instant gratification, and no `sudo`ing at all, and that seems good for quick adoption.
