### PR TITLE
Upload your own textures

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,33 +89,31 @@
             <div class="texCell" title="texture channel 0">
                 <img id="texture0" value="0" class="textureSlot" src="presets/previz/void.png" />
             </div>
-            <!-- none, keyboard, webcam, audio -->
-            <div class="texCell" title="no texture">
-                <img id="tex_none" class="textureOption" src="presets/previz/void.png" />
+            <div class="texCell">
+                <img id="" class="textureOption" src="" />
             </div>
-            <div class="texCell" title="keyboard">
-                <img id="tex_keyboard" class="textureOption" src="presets/previz/keyboard.png" />
+            <div class="texCell">
+                <img id="" class="textureOption" src="" />
             </div>
-            <div class="texCell" title="webcam">
-                <img id="tex_webcam" class="textureOption" src="presets/previz/webcam.png" />
+            <div class="texCell">
+                <img id="" class="textureOption" src="" />
             </div>
-            <div class="texCell" title="audio">
-                <img id="tex_audio" class="textureOption" src="presets/previz/audio.png" />
+            <div class="texCell">
+                <img id="" class="textureOption" src="" />
             </div>
         </div>
         <div class="tRow">
             <div class="texCell" title="texture channel 1">
                 <img id="texture1" class="textureSlot" src="presets/previz/void.png" />
             </div>
-            <!-- bw noise, color noise, ,  -->
-            <div class="texCell" title="noise bw">
-                <img id="tex_noisebw" class="textureOption" src="presets/previz/noisebw.png" />
+            <div class="texCell">
+                <img id="" class="textureOption" src="" />
             </div>
-            <div class="texCell" title="noise rgb">
-                <img id="tex_noisecolor" class="textureOption" src="presets/previz/noisecolor.png" />
+            <div class="texCell">
+                <img id="" class="textureOption" src="" />
             </div>
-            <div class="texCell" title="nyan animation">
-                <img id="tex_nyan" class="textureOption" src="presets/previz/nyanIcon.png" />
+            <div class="texCell">
+                <img id="" class="textureOption" src="" />
             </div>
             <div class="texCell">
                 <img id="" class="textureOption" src="" />

--- a/index.html
+++ b/index.html
@@ -79,6 +79,7 @@
     <div id="texturePanel" title="Textures">
         <button id="uploadCustomTexture">Upload Custom Texture</button>
         <input type="file" id="uploadCustomTextureFile" class="hide" multiple/>
+        <div id="maxCustomTextureSourcesReachedMessage" class="hide">Texture slots are full, can't add new custom textures</div>
         <div class="texTable">
             <div class="tRow">
                 <div class="texCell">

--- a/index.html
+++ b/index.html
@@ -76,81 +76,85 @@
         </div>
     </div>
     <!-- textures =================================================================================== -->
-    <div id="texturePanel" title="Textures" class="texTable">
-        <div class="tRow">
-            <div class="texCell">
-                <p>Slots</p>
+    <div id="texturePanel" title="Textures">
+        <button id="uploadCustomTexture">Upload Custom Texture</button>
+        <input type="file" id="uploadCustomTextureFile" class="hide"/>
+        <div class="texTable">
+            <div class="tRow">
+                <div class="texCell">
+                    <p>Slots</p>
+                </div>
+                <div class="texCell">
+                    <p>Options</p>
+                </div>
             </div>
-            <div class="texCell">
-                <p>Options</p>
+            <div class="tRow">
+                <div class="texCell" title="texture channel 0">
+                    <img id="texture0" value="0" class="textureSlot" src="presets/previz/void.png" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
             </div>
-        </div>
-        <div class="tRow">
-            <div class="texCell" title="texture channel 0">
-                <img id="texture0" value="0" class="textureSlot" src="presets/previz/void.png" />
+            <div class="tRow">
+                <div class="texCell" title="texture channel 1">
+                    <img id="texture1" class="textureSlot" src="presets/previz/void.png" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
             </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
+            <div class="tRow">
+                <div class="texCell" title="texture channel 2">
+                    <img id="texture2" class="textureSlot" src="presets/previz/void.png" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
             </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
-            </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
-            </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
-            </div>
-        </div>
-        <div class="tRow">
-            <div class="texCell" title="texture channel 1">
-                <img id="texture1" class="textureSlot" src="presets/previz/void.png" />
-            </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
-            </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
-            </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
-            </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
-            </div>
-        </div>
-        <div class="tRow">
-            <div class="texCell" title="texture channel 2">
-                <img id="texture2" class="textureSlot" src="presets/previz/void.png" />
-            </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
-            </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
-            </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
-            </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
-            </div>
-        </div>
-        <div class="tRow">
-            <div class="texCell" title="texture channel 3">
-                <img id="texture3" class="textureSlot" src="presets/previz/void.png" />
-            </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
-            </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
-            </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
-            </div>
-            <div class="texCell">
-                <img id="" class="textureOption" src="" />
+            <div class="tRow">
+                <div class="texCell" title="texture channel 3">
+                    <img id="texture3" class="textureSlot" src="presets/previz/void.png" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
+                <div class="texCell">
+                    <img id="" class="textureOption" src="" />
+                </div>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
     <!-- textures =================================================================================== -->
     <div id="texturePanel" title="Textures">
         <button id="uploadCustomTexture">Upload Custom Texture</button>
-        <input type="file" id="uploadCustomTextureFile" class="hide"/>
+        <input type="file" id="uploadCustomTextureFile" class="hide" multiple/>
         <div class="texTable">
             <div class="tRow">
                 <div class="texCell">

--- a/js/pageGlobals.js
+++ b/js/pageGlobals.js
@@ -785,6 +785,7 @@ $( document ).ready(function()
                 } catch (e){
                     if (e instanceof CantAddMoreCustomTextureSourcesError) {
                       $('#maxCustomTextureSourcesReachedMessage').show();
+                      $('#uploadCustomTexture').prop('disabled', true);
                     } else {
                         throw e;
                     }

--- a/js/pageGlobals.js
+++ b/js/pageGlobals.js
@@ -731,6 +731,50 @@ $( document ).ready(function()
 
     defaultTextureSources.forEach(loadTextureSource);
 
+    $('#uploadCustomTexture')
+        .click( function(event)
+        {
+            $('#uploadCustomTextureFile').click();
+        })
+    $('#uploadCustomTextureFile').change(function(event) {
+        const fileList = Array.from(event.target.files);
+        fileList.forEach(function(file) {
+
+            var reader = new FileReader();
+            
+            reader.onload = function(e) {
+                const newTextureSource = newTextureSourceFromFileContent(reader.result);
+                loadTextureSource(newTextureSource);
+            };
+
+            reader.readAsDataURL(file);
+        });
+    });
+
+    function newTextureSourceFromFileContent(fileContent) {
+        const newRandomName = Math.random().toString(36).substring(7);
+        return {
+            id: newRandomName,
+            name: newRandomName,
+            previewImageSrc: fileContent,
+            createTexture: function() {
+                const texture = {
+                    type: "tex_2D",
+                    globject: gl.createTexture(),
+                    image: new Image(),
+                    loaded: false,
+                };
+                texture.image.onload = function()
+                {
+                    createGLTextureNearest(gl, texture.image, texture.globject);
+                    texture.loaded = true;
+                }
+                texture.image.src = fileContent;
+                return texture;
+            }
+        };
+    }
+
     $('.textureOption')
         .click( function(event)
         {

--- a/js/pageGlobals.js
+++ b/js/pageGlobals.js
@@ -689,11 +689,11 @@ $( document ).ready(function()
         textureSourceSlotImg.src = textureSource.previewImageSrc;
     };
 
-    function newTextureSourceFromFileContent(fileContent) {
+    function newTextureSourceFromFileContent(fileName, fileContent) {
         const newRandomName = Math.random().toString(36).substring(7);
         return {
             id: newRandomName,
-            name: newRandomName,
+            name: fileName,
             previewImageSrc: fileContent,
             createTexture: function() {
                 const texture = {
@@ -775,11 +775,12 @@ $( document ).ready(function()
     $('#uploadCustomTextureFile').change(function(event) {
         const fileList = Array.from(event.target.files);
         fileList.forEach(function(file) {
-            var reader = new FileReader();
-            
+            const reader = new FileReader();
+            const fileName = file.name;
+
             reader.onload = function() {
                 try {
-                    const newTextureSource = newTextureSourceFromFileContent(reader.result);
+                    const newTextureSource = newTextureSourceFromFileContent(fileName, reader.result);
                     loadTextureSource(newTextureSource);
                 } catch (e){
                     if (e instanceof CantAddMoreCustomTextureSourcesError) {

--- a/js/pageGlobals.js
+++ b/js/pageGlobals.js
@@ -666,6 +666,8 @@ $( document ).ready(function()
 
     // Functions to work with texture sources
 
+    class CantAddMoreCustomTextureSourcesError extends Error { name = 'CantAddMoreCustomTextureSourcesError'; }
+
     function nextFreeTextureSourceSlot() {
         return Array.from(document.querySelectorAll('div.tRow > div.texCell'))
                     .find(function(textureSlot){
@@ -678,6 +680,8 @@ $( document ).ready(function()
         textureSources[textureSource.id] = textureSource;
 
         const textureSourceSlot = nextFreeTextureSourceSlot();
+        if(!textureSourceSlot)
+            throw new CantAddMoreCustomTextureSourcesError();
         const textureSourceSlotImg = textureSourceSlot.querySelector('img');
 
         textureSourceSlot.title = textureSource.name;
@@ -774,8 +778,16 @@ $( document ).ready(function()
             var reader = new FileReader();
             
             reader.onload = function() {
-                const newTextureSource = newTextureSourceFromFileContent(reader.result);
-                loadTextureSource(newTextureSource);
+                try {
+                    const newTextureSource = newTextureSourceFromFileContent(reader.result);
+                    loadTextureSource(newTextureSource);
+                } catch (e){
+                    if (e instanceof CantAddMoreCustomTextureSourcesError) {
+                      $('#maxCustomTextureSourcesReachedMessage').show();
+                    } else {
+                        throw e;
+                    }
+                }
             };
 
             reader.readAsDataURL(file);

--- a/js/pageGlobals.js
+++ b/js/pageGlobals.js
@@ -19,6 +19,7 @@ var mTime;
 var whichSlot;
 var debugging = false;
 var numScreens = 1;
+const textureSources = {};
 
 //for ace editor
 var mCompileTimer = null;
@@ -563,7 +564,9 @@ $( document ).ready(function()
         });
 
     const tex_none = {
-        previewImageSrc: 'none',
+        id: "tex_none",
+        name: "no texture",
+        previewImageSrc: "presets/previz/void.png",
         createTexture: function() {
             return {
                 type: null,
@@ -572,7 +575,9 @@ $( document ).ready(function()
         },
     }
     const tex_keyboard = {
-        previewImageSrc: 'presets/previz/keyboard.png',                
+        id: "tex_keyboard",
+        name: "keyboard",
+        previewImageSrc: "presets/previz/keyboard.png",
         createTexture: function() {
             const textureMData = new Uint8Array(256 * 2);
             for (var j = 0; j < (256 * 2); j++)
@@ -583,14 +588,16 @@ $( document ).ready(function()
             createKeyboardTexture(gl, globject);
 
             return {
-                type: 'tex_keyboard',
+                type: "tex_keyboard",
                 mData: textureMData,
                 globject: globject,
             }
         }
     }
     const tex_webcam = {
-        previewImageSrc: 'presets/previz/webcam.png',
+        id: "tex_webcam",
+        name: "webcam",
+        previewImageSrc: "presets/previz/webcam.png",
         createTexture: function() {
             if (mWebCam === null)
                 mWebCam = document.getElementById( 'video' )
@@ -615,7 +622,9 @@ $( document ).ready(function()
         }
     }
     const tex_audio = {
-        previewImageSrc: 'presets/previz/audio.png',
+        id: "tex_audio",
+        name: "audio",
+        previewImageSrc: "presets/previz/audio.png",
         createTexture: function() {
             if (mSound == null)
                 initAudio();
@@ -637,7 +646,9 @@ $( document ).ready(function()
         }
     }
     const tex_noisebw = {
-        previewImageSrc: 'presets/previz/noisebw.png',
+        id: "tex_noisebw",
+        name: "noise bw",
+        previewImageSrc: "presets/previz/noisebw.png",
         createTexture: function() {
             const texture = {
                 type: "tex_2D",
@@ -655,7 +666,9 @@ $( document ).ready(function()
         }
     }
     const tex_noisecolor = {
-        previewImageSrc: 'presets/previz/noisecolor.png',
+        id: "tex_noisecolor",
+        name: "noise rgb",
+        previewImageSrc: "presets/previz/noisecolor.png",
         createTexture: function() {
             const texture = {
                 type: "tex_2D",
@@ -673,7 +686,9 @@ $( document ).ready(function()
         }
     }
     const tex_nyan = {
-        previewImageSrc: 'presets/previz/nyanIcon.png',
+        id: "tex_nyan",
+        name: "nyan animation",
+        previewImageSrc: "presets/previz/nyanIcon.png",
         createTexture: function() {
             const texture = {
                 type: "tex_2D",
@@ -690,16 +705,38 @@ $( document ).ready(function()
             return texture;
         }
     };
-    const defaultTextureSources = {
-        tex_none, tex_keyboard, tex_webcam, tex_audio, tex_noisebw, tex_noisecolor, tex_nyan
+
+    function nextFreeTextureSourceSlot() {
+        return Array.from(document.querySelectorAll('div.tRow > div.texCell'))
+                    .find(function(textureSlot){
+                        const img = textureSlot.querySelector('img');
+                        return img && ("" == img.id);
+                    })
     };
+
+    function loadTextureSource(textureSource) {
+        textureSources[textureSource.id] = textureSource;
+
+        const textureSourceSlot = nextFreeTextureSourceSlot();
+        const textureSourceSlotImg = textureSourceSlot.querySelector('img');
+
+        textureSourceSlot.title = textureSource.name;
+        textureSourceSlotImg.id = textureSource.id;
+        textureSourceSlotImg.src = textureSource.previewImageSrc;
+    };
+
+    const defaultTextureSources = [
+        tex_none, tex_keyboard, tex_webcam, tex_audio, tex_noisebw, tex_noisecolor, tex_nyan
+    ];
+
+    defaultTextureSources.forEach(loadTextureSource);
 
     $('.textureOption')
         .click( function(event)
         {
             var slotID = whichSlot.slice(-1);
             destroyInput(slotID);
-            const textureSource = defaultTextureSources[event.target.id];
+            const textureSource = textureSources[event.target.id];
 
             $("#"+whichSlot)
                 .attr('src', textureSource.previewImageSrc)

--- a/js/pageGlobals.js
+++ b/js/pageGlobals.js
@@ -510,58 +510,12 @@ $( document ).ready(function()
     }
 
     //--------------------- TEXTURE PANEL ------------
-    $("#texturePanel")
-        .dialog({
-            autoOpen: false,
-            minWidth: 380,
-            show: {
-                effect: "clip",
-                duration: 250
-            },
-            hide: {
-                effect: "clip",
-                duration: 250
-            },
-            open: function(){
-                //fixes highlight close button
-                $(this).parents('.ui-dialog').attr('tabindex', -1)[0].focus();
-            }
-        });
 
-    $('.textureSlot')
-        .click( function(event)
-        {
-            $( ".textureSlot" ).animate(
-                {
-                    backgroundColor: "rgba(255, 255, 255, 0.5)",
-                }, .250 );
-            $(this).animate(
-                {
-                    backgroundColor: "rgba(0, 255, 0, 0.4)",
-                }, .250 );
-            whichSlot = event.target.id;
-        })
-        .hover( function(event)
-        {
-            $(this).animate(
-                {
-                    backgroundColor: "rgba(255, 255, 255, 1.0)",
-                }, .250 );
+    // A texture source is an element that can provide a texture
+    // It should have an id, a name and a previewImageSrc that are used to render the slot in the texture panel
+    // Also, it needs to have a createTexture() function that returns a texture
 
-        }, function(event)
-        {
-            $(this).animate(
-                {
-                    backgroundColor: "rgba(255, 255, 255, 0.5)",
-                }, .250 );
-            if (whichSlot == event.target.id)
-            {
-                $(this).animate(
-                {
-                    backgroundColor: "rgba(0, 255, 0, 0.4)",
-                }, .250 );
-            }
-        });
+    // Default texture sources
 
     const tex_none = {
         id: "tex_none",
@@ -706,6 +660,12 @@ $( document ).ready(function()
         }
     };
 
+    const defaultTextureSources = [
+        tex_none, tex_keyboard, tex_webcam, tex_audio, tex_noisebw, tex_noisecolor, tex_nyan
+    ];
+
+    // Functions to work with texture sources
+
     function nextFreeTextureSourceSlot() {
         return Array.from(document.querySelectorAll('div.tRow > div.texCell'))
                     .find(function(textureSlot){
@@ -724,32 +684,6 @@ $( document ).ready(function()
         textureSourceSlotImg.id = textureSource.id;
         textureSourceSlotImg.src = textureSource.previewImageSrc;
     };
-
-    const defaultTextureSources = [
-        tex_none, tex_keyboard, tex_webcam, tex_audio, tex_noisebw, tex_noisecolor, tex_nyan
-    ];
-
-    defaultTextureSources.forEach(loadTextureSource);
-
-    $('#uploadCustomTexture')
-        .click( function(event)
-        {
-            $('#uploadCustomTextureFile').click();
-        })
-    $('#uploadCustomTextureFile').change(function(event) {
-        const fileList = Array.from(event.target.files);
-        fileList.forEach(function(file) {
-
-            var reader = new FileReader();
-            
-            reader.onload = function(e) {
-                const newTextureSource = newTextureSourceFromFileContent(reader.result);
-                loadTextureSource(newTextureSource);
-            };
-
-            reader.readAsDataURL(file);
-        });
-    });
 
     function newTextureSourceFromFileContent(fileContent) {
         const newRandomName = Math.random().toString(36).substring(7);
@@ -774,6 +708,79 @@ $( document ).ready(function()
             }
         };
     }
+
+    $("#texturePanel")
+        .dialog({
+            autoOpen: false,
+            minWidth: 380,
+            show: {
+                effect: "clip",
+                duration: 250
+            },
+            hide: {
+                effect: "clip",
+                duration: 250
+            },
+            open: function(){
+                //fixes highlight close button
+                $(this).parents('.ui-dialog').attr('tabindex', -1)[0].focus();
+            }
+        });
+
+    $('.textureSlot')
+        .click( function(event)
+        {
+            $( ".textureSlot" ).animate(
+                {
+                    backgroundColor: "rgba(255, 255, 255, 0.5)",
+                }, .250 );
+            $(this).animate(
+                {
+                    backgroundColor: "rgba(0, 255, 0, 0.4)",
+                }, .250 );
+            whichSlot = event.target.id;
+        })
+        .hover( function(event)
+        {
+            $(this).animate(
+                {
+                    backgroundColor: "rgba(255, 255, 255, 1.0)",
+                }, .250 );
+
+        }, function(event)
+        {
+            $(this).animate(
+                {
+                    backgroundColor: "rgba(255, 255, 255, 0.5)",
+                }, .250 );
+            if (whichSlot == event.target.id)
+            {
+                $(this).animate(
+                {
+                    backgroundColor: "rgba(0, 255, 0, 0.4)",
+                }, .250 );
+            }
+        });
+
+    $('#uploadCustomTexture')
+        .click( function()
+        {
+            $('#uploadCustomTextureFile').click();
+        });
+
+    $('#uploadCustomTextureFile').change(function(event) {
+        const fileList = Array.from(event.target.files);
+        fileList.forEach(function(file) {
+            var reader = new FileReader();
+            
+            reader.onload = function() {
+                const newTextureSource = newTextureSourceFromFileContent(reader.result);
+                loadTextureSource(newTextureSource);
+            };
+
+            reader.readAsDataURL(file);
+        });
+    });
 
     $('.textureOption')
         .click( function(event)
@@ -809,6 +816,8 @@ $( document ).ready(function()
                     backgroundColor: "rgba(255, 255, 255, 0.25)",
                 }, .250 );
         });
+
+    defaultTextureSources.forEach(loadTextureSource);
 
     //--------------------- PROJECTION MAPPING PANEL ------------
     $("#edgesPanel")

--- a/js/pageGlobals.js
+++ b/js/pageGlobals.js
@@ -562,155 +562,154 @@ $( document ).ready(function()
             }
         });
 
+    const tex_none = {
+        previewImageSrc: 'none',
+        createTexture: function() {
+            return {
+                type: null,
+                globject: null,
+            }
+        },
+    }
+    const tex_keyboard = {
+        previewImageSrc: 'presets/previz/keyboard.png',                
+        createTexture: function() {
+            const textureMData = new Uint8Array(256 * 2);
+            for (var j = 0; j < (256 * 2); j++)
+            {
+                textureMData[j] = 0;
+            }
+            const globject = gl.createTexture()
+            createKeyboardTexture(gl, globject);
+
+            return {
+                type: 'tex_keyboard',
+                mData: textureMData,
+                globject: globject,
+            }
+        }
+    }
+    const tex_webcam = {
+        previewImageSrc: 'presets/previz/webcam.png',
+        createTexture: function() {
+            if (mWebCam === null)
+                mWebCam = document.getElementById( 'video' )
+
+            navigator.mediaDevices.getUserMedia({audio: false, video: true})
+                .then( function(stream) { //success
+                    mWebCam.srcObject = stream;
+                    mWebCam.play()
+                })
+                .catch( function(err) { //failure
+                    alert("Error getting user media stream." + err);
+                    mWebCam = null
+                });
+
+            const globject = gl.createTexture();
+            createVideoTexture(gl, globject, mWebCam);
+
+            return {
+                type: 'tex_webcam',
+                globject: globject,
+            }
+        }
+    }
+    const tex_audio = {
+        previewImageSrc: 'presets/previz/audio.png',
+        createTexture: function() {
+            if (mSound == null)
+                initAudio();
+
+            const textureMData = new Uint8Array(512 * 2);
+            for (var j = 0; j < (512 * 2); j++)
+            {
+                textureMData[j] = 0;
+            }
+
+            const globject = gl.createTexture();
+            createAudioTexture(gl, globject);
+
+            return {
+                type: "tex_audio",
+                globject: globject,
+                mData: textureMData,
+            }
+        }
+    }
+    const tex_noisebw = {
+        previewImageSrc: 'presets/previz/noisebw.png',
+        createTexture: function() {
+            const texture = {
+                type: "tex_2D",
+                globject: gl.createTexture(),
+                image: new Image(),
+                loaded: false,
+            };
+            texture.image.onload = function()
+            {
+                createGLTextureNearestRepeat( gl, texture.image, texture.globject);
+                texture.loaded = true;
+            }
+            texture.image.src = 'presets/noisebw.png';
+            return texture;
+        }
+    }
+    const tex_noisecolor = {
+        previewImageSrc: 'presets/previz/noisecolor.png',
+        createTexture: function() {
+            const texture = {
+                type: "tex_2D",
+                globject: gl.createTexture(),
+                image: new Image(),
+                loaded: false,
+            };
+            texture.image.onload = function()
+            {
+                createGLTextureNearestRepeat( gl, texture.image, texture.globject);
+                texture.loaded = true;
+            }
+            texture.image.src = 'presets/noisecolor.png';
+            return texture;
+        }
+    }
+    const tex_nyan = {
+        previewImageSrc: 'presets/previz/nyanIcon.png',
+        createTexture: function() {
+            const texture = {
+                type: "tex_2D",
+                globject: gl.createTexture(),
+                image: new Image(),
+                loaded: false,
+            };
+            texture.image.onload = function()
+            {
+                createGLTextureNearest(gl, texture.image, texture.globject);
+                texture.loaded = true;
+            }
+            texture.image.src = 'presets/nyan.png';
+            return texture;
+        }
+    };
+    const defaultTextureSources = {
+        tex_none, tex_keyboard, tex_webcam, tex_audio, tex_noisebw, tex_noisecolor, tex_nyan
+    };
+
     $('.textureOption')
         .click( function(event)
         {
             var slotID = whichSlot.slice(-1);
             destroyInput(slotID);
-            var texture = {};
+            const textureSource = defaultTextureSources[event.target.id];
 
-            switch (event.target.id)
-            {
-                case "tex_none":
-                    texture.type = null;
-                    texture.globject = null;
-                    $("#"+whichSlot)
-                        .attr('src', 'none')
-                        .animate(
-                            {
-                                backgroundColor: "rgba(255, 255, 255, 0.5)",
-                            }, .250 );;
-                    whichSlot = "";
-                    break;
-
-                case "tex_keyboard":
-                    texture.type = "tex_keyboard"
-                    texture.globject =  gl.createTexture();
-                    $("#"+whichSlot)
-                        .attr('src', 'presets/previz/keyboard.png')
-                        .animate(
-                        {
-                            backgroundColor: "rgba(255, 255, 255, 0.5)",
-                        }, .250 );
-                    whichSlot = "";
-
-                    texture.mData = new Uint8Array(256 * 2);
-                    for (var j = 0; j < (256 * 2); j++)
+            $("#"+whichSlot)
+                .attr('src', textureSource.previewImageSrc)
+                .animate(
                     {
-                        texture.mData[j] = 0;
-                    }
-
-                    createKeyboardTexture( gl, texture.globject);
-                    break;
-
-                case "tex_webcam":
-                    if (mWebCam === null)
-                        mWebCam = document.getElementById( 'video' )
-
-                    navigator.mediaDevices.getUserMedia({audio: false, video: true})
-                        .then( function(stream) { //success
-                            mWebCam.srcObject = stream;
-                            mWebCam.play()
-                        })
-                        .catch( function(err) { //failure
-                            alert("Error getting user media stream." + err);
-                            mWebCam = null
-                        });
-
-                    texture.type = "tex_webcam";
-                    texture.globject =  gl.createTexture();
-                    $("#"+whichSlot)
-                        .attr('src', 'presets/previz/webcam.png')
-                        .animate(
-                            {
-                                backgroundColor: "rgba(255, 255, 255, 0.5)",
-                            }, .250 );
-                    whichSlot = "";
-                    createVideoTexture(gl,texture.globject, mWebCam);
-                    break;
-
-                case "tex_audio":
-                    if (mSound == null)
-                        initAudio();
-                    texture.type = "tex_audio";
-                    texture.globject =  gl.createTexture();
-                    $("#"+whichSlot)
-                        .attr('src', 'presets/previz/audio.png')
-                        .animate(
-                        {
-                            backgroundColor: "rgba(255, 255, 255, 0.5)",
-                        }, .250 );
-                    whichSlot = "";
-
-                    texture.mData = new Uint8Array(512 * 2);
-                    for (var j = 0; j < (512 * 2); j++)
-                    {
-                        texture.mData[j] = 0;
-                    }
-                    createAudioTexture( gl, texture.globject);
-                    break;
-
-                case "tex_noisebw":
-                    texture.type = "tex_2D";
-                    texture.globject =  gl.createTexture();
-                    texture.image = new Image();
-                    texture.loaded = false;
-                    $("#"+whichSlot)
-                        .attr('src', 'presets/previz/noisebw.png')
-                        .animate(
-                        {
-                            backgroundColor: "rgba(255, 255, 255, 0.5)",
-                        }, .250 );
-                    whichSlot = "";
-
-                    texture.image.onload = function()
-                    {
-                        createGLTextureNearestRepeat( gl, texture.image, texture.globject);
-                        texture.loaded = true;
-                    }
-                    texture.image.src = 'presets/noisebw.png';
-                    break;
-
-                case "tex_noisecolor":
-                    texture.type = "tex_2D";
-                    texture.globject =  gl.createTexture();
-                    texture.image = new Image();
-                    texture.loaded = false;
-                    $("#"+whichSlot)
-                        .attr('src', 'presets/previz/noisecolor.png')
-                        .animate(
-                        {
-                            backgroundColor: "rgba(255, 255, 255, 0.5)",
-                        }, .250 );
-                    whichSlot = "";
-
-                    texture.image.onload = function()
-                    {
-                        createGLTextureNearestRepeat( gl, texture.image, texture.globject);
-                        texture.loaded = true;
-                    }
-                    texture.image.src = 'presets/noisecolor.png';
-                    break;
-
-                case "tex_nyan":
-                    texture.type = "tex_2D";
-                    texture.globject = gl.createTexture();
-                    texture.image = new Image();
-                    texture.loaded = false;
-                    $("#"+whichSlot)
-                        .attr('src', 'presets/previz/nyanIcon.png')
-                        .animate(
-                            {
-                                backgroundColor: "rgba(255, 255, 255, 0.5)",
-                            }, .250 );
-                    whichSlot = "";
-                    texture.image.onload = function()
-                    {
-                        createGLTextureNearest(gl, texture.image, texture.globject);
-                        texture.loaded = true;
-                    }
-                    texture.image.src = 'presets/nyan.png';
-            }
+                        backgroundColor: "rgba(255, 255, 255, 0.5)",
+                    }, .250 );
+            whichSlot = ""
+            
+            const texture = textureSource.createTexture();
 
             mInputs[slotID] = texture;
             createInputStr();


### PR DESCRIPTION
# What

This implements what was requested on https://github.com/shawnlawson/The_Force/issues/16, which is allowing the users to upload custom textures.

# How

First of all some refactors were made to allow textures to be added programatically instead of having them hardcoded. This includes:
- Removing the ids and names of the known textures (noise, nyan cat, audio, webcam, etc) from the html.
- Create a "texture source" object for each known texture, that contains the info to be displayed in the html + a function that creates the texture itself.

With that implemented, then added a button in the texture panel that allows file uploads. For each file uploaded it creates a new texture source and adds it to the texture panel. In case someone tries to add more textures than slots available, an message is shown in the texture panel to notify that the max number of textures was reached. I think this could be improved in the feature to allow even more textures.

**Notes:** it's not being checked whether the image was already uploaded or not, that could be improved.

# How it looks

Using custom textures for a shader:
![ejemploUploadCustomTextures](https://user-images.githubusercontent.com/11432672/98498154-d4d79f80-2224-11eb-9d26-d873aad4412b.gif)

Error message when too many custom textures were uploaded:
![errorMessageTooManyTextures](https://user-images.githubusercontent.com/11432672/98498701-35b3a780-2226-11eb-9685-b22bf6b3cc14.gif)
