### PR TITLE
Empty texture slots

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -85,9 +85,23 @@ body, html {
     height: auto;
 }
 
+.texClose.textureOption {
+    width: 15px;
+    height: 15px;
+    right: -7px;
+    top: -7px;
+    position: absolute;
+    z-index: 100;
+}
+
+.texClose.textureOption:hover {
+    background-color: rgb(255, 255, 255);
+}
+
 .texCell{
     display: table-cell;
     width: 60px;
+    position: relative;
 }
 .texCell > p{
     padding-left: 5px;

--- a/index.html
+++ b/index.html
@@ -94,16 +94,16 @@
                 <div class="texCell" title="texture channel 0">
                     <img id="texture0" value="0" class="textureSlot" src="presets/previz/void.png" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
             </div>
@@ -111,16 +111,16 @@
                 <div class="texCell" title="texture channel 1">
                     <img id="texture1" class="textureSlot" src="presets/previz/void.png" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
             </div>
@@ -128,16 +128,16 @@
                 <div class="texCell" title="texture channel 2">
                     <img id="texture2" class="textureSlot" src="presets/previz/void.png" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
             </div>
@@ -145,16 +145,16 @@
                 <div class="texCell" title="texture channel 3">
                     <img id="texture3" class="textureSlot" src="presets/previz/void.png" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
-                <div class="texCell">
+                <div class="texCell" data-has-texture="false">
                     <img id="" class="textureOption" src="" />
                 </div>
             </div>

--- a/js/pageGlobals.js
+++ b/js/pageGlobals.js
@@ -806,8 +806,7 @@ $( document ).ready(function()
                     loadTextureSource(newTextureSource);
                 } catch (e){
                     if (e instanceof CantAddMoreCustomTextureSourcesError) {
-                      $('#maxCustomTextureSourcesReachedMessage').show();
-                      $('#uploadCustomTexture').prop('disabled', true);
+                        console.warn(`Texture ${fileName} could not be uploaded because the texture panel is full.`);
                     } else {
                         throw e;
                     }

--- a/js/pageGlobals.js
+++ b/js/pageGlobals.js
@@ -669,11 +669,16 @@ $( document ).ready(function()
     class CantAddMoreCustomTextureSourcesError extends Error { name = 'CantAddMoreCustomTextureSourcesError'; }
 
     function nextFreeTextureSourceSlot() {
-        return Array.from(document.querySelectorAll('div.tRow > div.texCell'))
+        const nextFreeSlot = Array.from(document.querySelectorAll('div.tRow > div.texCell'))
                     .find(function(textureSlot){
                         const img = textureSlot.querySelector('img');
                         return img && ("" == img.id);
-                    })
+                    });
+
+        if(!nextFreeSlot)
+            throw new CantAddMoreCustomTextureSourcesError();
+        
+        return nextFreeSlot;
     };
 
     function removeTextureSourceButtonFor(textureSourceSlot) {
@@ -682,28 +687,25 @@ $( document ).ready(function()
         removeTextureButton.classList.add("textureOption", "texClose");
 
         $(removeTextureButton).click(function() {
-            const textureSourceSlotImg = textureSourceSlot.querySelector('img');
-
-            textureSourceSlot.title = ""
-            textureSourceSlotImg.id = ""
-            textureSourceSlotImg.src = ""
+            fillTextureSlotWith(textureSourceSlot, { name: "", id: "", previewImageSrc: "" });
             textureSourceSlot.removeChild(removeTextureButton);
         });
 
         return removeTextureButton;
     }
 
+    function fillTextureSlotWith(textureSourceSlot, {name, id, previewImageSrc}) {
+        textureSourceSlot.title = name;
+        const textureSourceSlotImg = textureSourceSlot.querySelector('img');
+        textureSourceSlotImg.id = id;
+        textureSourceSlotImg.src = previewImageSrc;
+    }
+
     function loadTextureSource(textureSource) {
         textureSources[textureSource.id] = textureSource;
 
         const textureSourceSlot = nextFreeTextureSourceSlot();
-        if(!textureSourceSlot)
-            throw new CantAddMoreCustomTextureSourcesError();
-        const textureSourceSlotImg = textureSourceSlot.querySelector('img');
-
-        textureSourceSlot.title = textureSource.name;
-        textureSourceSlotImg.id = textureSource.id;
-        textureSourceSlotImg.src = textureSource.previewImageSrc;
+        fillTextureSlotWith(textureSourceSlot, textureSource);
 
         const removeTextureSourceButton = removeTextureSourceButtonFor(textureSourceSlot);
         textureSourceSlot.appendChild(removeTextureSourceButton); 

--- a/js/pageGlobals.js
+++ b/js/pageGlobals.js
@@ -676,6 +676,23 @@ $( document ).ready(function()
                     })
     };
 
+    function removeTextureSourceButtonFor(textureSourceSlot) {
+        const removeTextureButton = document.createElement("img");
+        removeTextureButton.setAttribute("src", "presets/previz/void.png");
+        removeTextureButton.classList.add("textureOption", "texClose");
+
+        $(removeTextureButton).click(function() {
+            const textureSourceSlotImg = textureSourceSlot.querySelector('img');
+
+            textureSourceSlot.title = ""
+            textureSourceSlotImg.id = ""
+            textureSourceSlotImg.src = ""
+            textureSourceSlot.removeChild(removeTextureButton);
+        });
+
+        return removeTextureButton;
+    }
+
     function loadTextureSource(textureSource) {
         textureSources[textureSource.id] = textureSource;
 
@@ -687,6 +704,9 @@ $( document ).ready(function()
         textureSourceSlot.title = textureSource.name;
         textureSourceSlotImg.id = textureSource.id;
         textureSourceSlotImg.src = textureSource.previewImageSrc;
+
+        const removeTextureSourceButton = removeTextureSourceButtonFor(textureSourceSlot);
+        textureSourceSlot.appendChild(removeTextureSourceButton); 
     };
 
     function newTextureSourceFromFileContent(fileName, fileContent) {

--- a/js/pageGlobals.js
+++ b/js/pageGlobals.js
@@ -521,6 +521,7 @@ $( document ).ready(function()
         id: "tex_none",
         name: "no texture",
         previewImageSrc: "presets/previz/void.png",
+        removable: false,
         createTexture: function() {
             return {
                 type: null,
@@ -532,6 +533,7 @@ $( document ).ready(function()
         id: "tex_keyboard",
         name: "keyboard",
         previewImageSrc: "presets/previz/keyboard.png",
+        removable: false,
         createTexture: function() {
             const textureMData = new Uint8Array(256 * 2);
             for (var j = 0; j < (256 * 2); j++)
@@ -552,6 +554,7 @@ $( document ).ready(function()
         id: "tex_webcam",
         name: "webcam",
         previewImageSrc: "presets/previz/webcam.png",
+        removable: false,
         createTexture: function() {
             if (mWebCam === null)
                 mWebCam = document.getElementById( 'video' )
@@ -579,6 +582,7 @@ $( document ).ready(function()
         id: "tex_audio",
         name: "audio",
         previewImageSrc: "presets/previz/audio.png",
+        removable: false,
         createTexture: function() {
             if (mSound == null)
                 initAudio();
@@ -603,6 +607,7 @@ $( document ).ready(function()
         id: "tex_noisebw",
         name: "noise bw",
         previewImageSrc: "presets/previz/noisebw.png",
+        removable: true,
         createTexture: function() {
             const texture = {
                 type: "tex_2D",
@@ -623,6 +628,7 @@ $( document ).ready(function()
         id: "tex_noisecolor",
         name: "noise rgb",
         previewImageSrc: "presets/previz/noisecolor.png",
+        removable: true,
         createTexture: function() {
             const texture = {
                 type: "tex_2D",
@@ -643,6 +649,7 @@ $( document ).ready(function()
         id: "tex_nyan",
         name: "nyan animation",
         previewImageSrc: "presets/previz/nyanIcon.png",
+        removable: true,
         createTexture: function() {
             const texture = {
                 type: "tex_2D",
@@ -692,7 +699,8 @@ $( document ).ready(function()
         textureSourceSlotImg.src = "";
 
         const removeTextureButton = textureSourceSlot.querySelector('.texClose');
-        textureSourceSlot.removeChild(removeTextureButton);
+        if(removeTextureButton)
+            textureSourceSlot.removeChild(removeTextureButton);
 
         textureSourceSlot.setAttribute('data-has-texture', false);
     };
@@ -704,8 +712,10 @@ $( document ).ready(function()
         textureSourceSlotImg.id = textureSource.id;
         textureSourceSlotImg.src = textureSource.previewImageSrc;
 
-        const removeTextureSourceButton = removeTextureSourceButtonFor(textureSourceSlot);
-        textureSourceSlot.appendChild(removeTextureSourceButton);
+        if(textureSource.removable) {
+            const removeTextureSourceButton = removeTextureSourceButtonFor(textureSourceSlot);
+            textureSourceSlot.appendChild(removeTextureSourceButton);
+        };
 
         textureSourceSlot.setAttribute('data-has-texture', true);
     };
@@ -726,6 +736,7 @@ $( document ).ready(function()
             id: newRandomName,
             name: fileName,
             previewImageSrc: fileContent,
+            removable: true,
             createTexture: function() {
                 const texture = {
                     type: "tex_2D",


### PR DESCRIPTION
# What

Fixes #30 , allow texture slots to be emptied in order to use new custom ones.

# Changes

Added a little button at the corner of the texture slots that when clicked empties that slot.
In order to do that:
- added new css for the style of that button.
- modified the logic of loading a new texture to create it if the texture source is removable.
  - added a removable field to the texture sources, set it to true only for 2d textures and uploaded textures.
- added an attribute called `data-has-texture` to all slots that can hold a texture source to listen to changes on that attribute to trigger the enable/disable of the upload button. Also, took advantage of this to make the code to find a free slot simpler.

Also, changed the error that was being thrown before when a texture could not be uploaded by a warning that is shown in the console to let the user know that the texture wasn't uploaded.

**Note:** the no texture image was used for the button to remove textures but feel free to change that by any other image :)

# How does it look

### Adding/removing texture sources

![Usage of The Force, new textures are added to the texture panel and selected as active texture. Then, the texture is removed from the texture panel and another textures are uploaded.](https://user-images.githubusercontent.com/11432672/99342685-332b0080-286b-11eb-9049-1a44b67eecab.gif)

### Disabling/enabling upload button based on whether there are free slots for textures

![Using The Force to upload as many textures as texture slots, this disables the button to add new textures and shows an error message. Also, when removing textures the button is enabled and the error message disappears.](https://user-images.githubusercontent.com/11432672/99342722-43db7680-286b-11eb-838f-f575c4a57b26.gif)



