### PR TITLE
fixed the MIDI select menu issue

### DIFF
--- a/js/pageGlobals.js
+++ b/js/pageGlobals.js
@@ -73,7 +73,7 @@ $( document ).ready(function()
         {
             populateMIDIInSelect();
         })
-        .on("selectmenuchange", function(event)
+        .on("selectmenuselect", function(event)
         {
             startLoggingMIDIInput($("#selectMIDIIn").val());
         });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/797993/144662836-a3fb3d4d-5517-4875-81c3-59f4935178d2.png)

There was a problem with this jquery ui select: it didn't trigger when the MIDI device was chosen. I fixed this by changing the event name.

Tested with MIDI Fighter Twister and it worked.